### PR TITLE
Bind VNC port directly to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - <PATH_GOES_HERE>:/root/mrg_ws # Replace <PATH_GOES_HERE> with the path to your mrg_ws folder (If you cloned it to your home directory in WSL this would be /home/$USER/mrg_ws)
     ports:
-      - 6080:80
+      - 127.0.0.1:6080:80
       - 9090:9090
       - 8080:8080
     tty: true


### PR DESCRIPTION
Currently, the port is exposed directly to the machine, which means anyone can access the VNC if they know your IP address. This change will map the port directly to the machine's localhost, which closes the port from the outside. 